### PR TITLE
Fix MacOS /tmp symlink

### DIFF
--- a/rplugin/python3/nvim_http/response.py
+++ b/rplugin/python3/nvim_http/response.py
@@ -12,7 +12,7 @@ def get_http_response_buf(nvim: Nvim):
     """
     Get the buffer object of the HTTP response.
     """
-    response_bufs = [buf for buf in nvim.buffers if buf.name == response_bufname]
+    response_bufs = [buf for buf in nvim.buffers if response_bufname in buf.name]
     return response_bufs[0] if response_bufs else None
 
 


### PR DESCRIPTION
On macOS, `/tmp` is by default a symbolic link to `/private/tmp`. (just like `/var`).
So when nvim inializes a buffer, its name is not `/tmp/response.http` but rather `/private/tmp/response.http`.

The PR just basically makes sure that nvim still opens the set `response_bufname` even if it was symlinked to any other directory, which fixes the MacOS bug as well
